### PR TITLE
Add a new guardrail for deleting unused IAM user access keys

### DIFF
--- a/guardrails/delete_unused_iam_access_keys.yaml
+++ b/guardrails/delete_unused_iam_access_keys.yaml
@@ -1,0 +1,19 @@
+authors: Isaac Lepow
+name: Delete Unused IAM Access Keys
+categories: Process
+functions: Security
+resources: IAM Users
+maturity: Low
+csps: AWS
+applies: To IAM users
+summary: Delete IAM access keys that have not been used recently
+how_to:
+description: |
+  In the situations where IAM users are still required, or for existing IAM users that haven not/can not be migrated to IAM roles, access keys should be deleted if they are not in use. 
+  
+  How frequently an access key must be used may vary based on your specific security requirements, but CIS recommends removing IAM credentials that have been unused for 45 days or more. 
+  
+  Removing unused access limits the impact of abandoned or forgotten credentials, and reduces the window of opportunity for attackers to use compromised credentials.
+
+links:
+  - https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-22

--- a/guardrails/delete_unused_iam_access_keys.yaml
+++ b/guardrails/delete_unused_iam_access_keys.yaml
@@ -8,7 +8,7 @@ csps: AWS
 applies: To IAM users
 summary: Delete IAM access keys that have not been used recently
 how_to: |
-  An access key's most recent usage can be identified in the console or CLI, or by generating an IAM credential report for the AWS account where it resides: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_finding-unused.html#finding-unused-access-keys
+  An access key's most recent usage can be identified in the console or CLI, or by generating an IAM credential report for the AWS account where it resides.
 
   Automatic remediation can be achieved using custom automation, e.g. a Lambda function or Cloud Custodian.
 description: |
@@ -20,3 +20,5 @@ description: |
 
 links:
   - https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-22
+  - https://docs.aws.amazon.com/config/latest/developerguide/iam-user-unused-credentials-check.html
+  - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_finding-unused.html#finding-unused-access-keys

--- a/guardrails/delete_unused_iam_access_keys.yaml
+++ b/guardrails/delete_unused_iam_access_keys.yaml
@@ -7,7 +7,10 @@ maturity: Low
 csps: AWS
 applies: To IAM users
 summary: Delete IAM access keys that have not been used recently
-how_to:
+how_to: |
+  An access key's most recent usage can be identified in the console or CLI, or by generating an IAM credential report for the AWS account where it resides: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_finding-unused.html#finding-unused-access-keys
+
+  Automatic remediation can be achieved using custom automation, e.g. a Lambda function or Cloud Custodian.
 description: |
   In the situations where IAM users are still required, or for existing IAM users that haven not/can not be migrated to IAM roles, access keys should be deleted if they are not in use. 
   


### PR DESCRIPTION
In a similar vein to the guardrail requiring that access keys be rotated regularly, access keys that are no longer in active use should be deleted. CIS recommends removing or deactivating credentials that have been unused for 45 days or more. 

I included a very brief overview of the steps for detecting and automatically removing unused access keys in the `how_to` field. 